### PR TITLE
Fix uuid transitive vulnerability (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13688,13 +13688,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "lodash-es": "^4.18.0",
     "serialize-javascript": "^7.0.5",
     "path-to-regexp": "^0.1.13",
+    "uuid": "^14.0.0",
     "yaml": "^1.10.3",
     "minimatch@3": {
       "brace-expansion": "^1.1.13"


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #97: `uuid` missing buffer bounds check in v3/v5/v6 when `buf` is provided ([GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)).
- Adds a `uuid: ^14.0.0` override in `package.json` so the transitive `uuid@8.3.2` (pulled via `@lhci/cli`) bumps to the patched `14.0.0`.
- `npm audit fix` wanted to downgrade `@lhci/cli` to `0.6.1` — overriding the nested dep keeps `@lhci/cli` on `0.15.1`.

## Test plan
- [x] `npm install` succeeds
- [x] `npm ls uuid` resolves to `uuid@14.0.0` under `@lhci/cli`
- [x] `npm audit` reports `found 0 vulnerabilities`
- [ ] CI green